### PR TITLE
crashplan 4.7.0 and openjdk-8-jdk-headless 8u91-b14-3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
       - qemu-user-static
       - binfmt-support
       - php5-cli
+      - unzip
 
 cache:
   directories:
@@ -21,11 +22,14 @@ install:
   - update-binfmts --display
   - sudo mkdir -p -m 777 /mnt/DroboFS/Shares/DroboApps
   - mkdir -p $HOME/xtools/toolchain/5n
-  - if [ ! -f $HOME/xtools/toolchain/5n/arm7-tools.tgz ]; then
-    wget -O $HOME/xtools/toolchain/5n/arm7-tools.tgz https://copy.com/nBZXoz3NdvFX%2FDroboAppsDS%2Farm7-tools.gz?download=1 ;
+  - if [ ! -f $HOME/xtools/toolchain/5n/SDK-2.1.zip ]; then
+    wget -O $HOME/xtools/toolchain/5n/SDK-2.1.zip ftp://updates.drobo.com/droboapps/development/SDK-2.1.zip ;
+    fi
+  - if [ ! -f $HOME/xtools/toolchain/5n/arm7-tools.gz ]; then
+    unzip -j $HOME/xtools/toolchain/5n/SDK-2.1.zip -d $HOME/xtools/toolchain/5n "DroboApps SDK 2.1/arm7-tools.gz" ;
     fi
   - if [ ! -d $HOME/xtools/toolchain/5n/bin ]; then
-    tar -zxf $HOME/xtools/toolchain/5n/arm7-tools.tgz -C $HOME/xtools/toolchain/5n ;
+    tar -zxf $HOME/xtools/toolchain/5n/arm7-tools.gz -C $HOME/xtools/toolchain/5n ;
     fi
   - $HOME/xtools/toolchain/5n/bin/arm-marvell-linux-gnueabi-gcc --version
 

--- a/app.sh
+++ b/app.sh
@@ -89,7 +89,7 @@ popd
 
 ### CRASHPLAN ###
 _build_crashplan() {
-local VERSION="4.5.2"
+local VERSION="4.7.0"
 local FOLDER="crashplan-install"
 local FILE="CrashPlan_${VERSION}_Linux.tgz"
 local URL="http://download.code42.com/installs/linux/install/CrashPlan/${FILE}"

--- a/app.sh
+++ b/app.sh
@@ -10,7 +10,7 @@ _download_deb() {
   return 0
 }
 
-JAVA_VERSION="8u91-b14-3"
+JAVA_VERSION="8u102-b14.1-2"
 JAVA_INCLUDE="${PWD}/target/openjdk-8-jdk-headless_${JAVA_VERSION}/usr/lib/jvm/java-8-openjdk-armel/include"
 JAVA_INCLUDE_LINUX="${JAVA_INCLUDE}/linux"
 

--- a/app.sh
+++ b/app.sh
@@ -10,14 +10,14 @@ _download_deb() {
   return 0
 }
 
-JAVA_VERSION="8u72-b05-6"
-JAVA_INCLUDE="${PWD}/target/openjdk-8-jdk_${JAVA_VERSION}/usr/lib/jvm/java-8-openjdk-armel/include"
+JAVA_VERSION="8u91-b14-3"
+JAVA_INCLUDE="${PWD}/target/openjdk-8-jdk-headless_${JAVA_VERSION}/usr/lib/jvm/java-8-openjdk-armel/include"
 JAVA_INCLUDE_LINUX="${JAVA_INCLUDE}/linux"
 
 ### JRE INCLUDES ###
 _build_jre() {
 local VERSION="${JAVA_VERSION}"
-local FOLDER="openjdk-8-jdk_${VERSION}"
+local FOLDER="openjdk-8-jdk-headless_${VERSION}"
 local FILE="${FOLDER}_armel.deb"
 local URL="http://ftp.debian.org/debian/pool/main/o/openjdk-8/${FILE}"
 

--- a/src/dest/service.sh
+++ b/src/dest/service.sh
@@ -7,7 +7,7 @@
 
 framework_version="2.1"
 name="crashplan"
-version="4.5.2"
+version="4.7.0"
 description="Online Data Backup - Offsite, Onsite, And Cloud."
 depends="java8 locale"
 webui="WebUI"

--- a/src/dest/www/includes/changelog.php
+++ b/src/dest/www/includes/changelog.php
@@ -1,3 +1,7 @@
+<p>Changes from 4.7.0:</p>
+<ol>
+  <li>Crashplan updated to version 4.7.0 (<a href="https://support.code42.com/Release_Notes" target="_new">full changelog</a>).</li>
+</ol>
 <p>Changes from 4.5.0:</p>
 <ol>
   <li>Crashplan updated to version 4.5.2 (<a href="https://support.code42.com/Release_Notes" target="_new">full changelog</a>).</li>

--- a/src/dest/www/includes/variables.php
+++ b/src/dest/www/includes/variables.php
@@ -1,7 +1,7 @@
 <?php 
 $app = "crashplan";
 $appname = "Crashplan";
-$appversion = "4.5.2";
+$appversion = "4.7.0";
 $appsite = "https://www.code42.com/crashplan/";
 $apphelp = "https://support.code42.com/CrashPlan";
 $apppage = "https://www.crashplan.com/account/login.vtl";


### PR DESCRIPTION
Built using docker a few weeks ago and working on my Drobo 5n since then.

Looks like openjdk-8-jdk-headless has been updated a few times since then.
